### PR TITLE
Add decorator example to Stimulus app

### DIFF
--- a/frameworks/stimulus/3/src/index.js
+++ b/frameworks/stimulus/3/src/index.js
@@ -5,5 +5,6 @@ import { installErrorHandler } from "@appsignal/stimulus"
 
 const application = Application.start()
 installErrorHandler(appsignal, application)
+appsignal.addDecorator((span) => span.setTags({userId: "abc123"}))
 const context = require.context("./controllers", true, /\.js$/)
 application.load(definitionsFromContext(context))


### PR DESCRIPTION
This is one of the features in the front-end integration that we don't talk about that much. It'd be nice to have an example that we can share with users.

Prompted by [this issue](https://github.com/appsignal/appsignal-javascript/pull/600#issuecomment-1620052367).